### PR TITLE
add flux toolkit for automatic application deployment

### DIFF
--- a/cmd/create/eks/command.go
+++ b/cmd/create/eks/command.go
@@ -58,6 +58,19 @@ repository. Some api server deployed in the created cluster would be
 available like shown below.
 
     apiserver.kia02.aws.example.com
+
+Executing this command has several requirements to be satisfied in order to
+function correctly. The following tools need to be installed and accessible
+in the program's path.
+
+    aws                      https://aws.amazon.com/cli
+    aws-iam-authenticator    https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
+    eksctl                   https://eksctl.io
+    flux                     https://fluxcd.io
+    helm                     https://helm.sh
+    istioctl                 https://istio.io
+    kubectl                  https://kubernetes.io/docs/tasks/tools/install-kubectl
+    red                      https://github.com/xh3b4sd/red
 `
 )
 
@@ -79,6 +92,7 @@ func New(config Config) (*cobra.Command, error) {
 					"aws",
 					"aws-iam-authenticator",
 					"eksctl",
+					"flux",
 					"helm",
 					"istioctl",
 					"kubectl",

--- a/cmd/create/eks/runner.go
+++ b/cmd/create/eks/runner.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"io"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
@@ -324,6 +325,29 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if err != nil {
 			return tracer.Maskf(executionFailedError, "%s", out)
 		}
+	}
+
+	{
+		r.logger.Log(ctx, "level", "info", "message", "installing flux toolkit")
+
+		os.Setenv("GITHUB_TOKEN", secrets["github.flux.token"])
+
+		out, err = exec.Command(
+			"flux",
+			"bootstrap",
+			"github",
+			"--owner",
+			"venturemark",
+			"--repository",
+			"flux",
+			"--token-auth",
+			"true",
+		).CombinedOutput()
+		if err != nil {
+			return tracer.Maskf(executionFailedError, "%s", out)
+		}
+
+		os.Unsetenv("GITHUB_TOKEN")
 	}
 
 	return nil

--- a/cmd/create/knd/command.go
+++ b/cmd/create/knd/command.go
@@ -28,6 +28,18 @@ from which secret data is read. Add the following line to your config file
 according to your local setup.
 
     sec: "~/project/xh3b4sd/sec/"
+
+Executing this command has several requirements to be satisfied in order to
+function correctly. The following tools need to be installed and accessible
+in the program's path.
+
+    docker      https://www.docker.com
+    flux        https://fluxcd.io
+    helm        https://helm.sh
+    istioctl    https://istio.io
+    kind        https://kind.sigs.k8s.io
+    kubectl     https://kubernetes.io/docs/tasks/tools/install-kubectl
+    red         https://github.com/xh3b4sd/red
 `
 )
 
@@ -47,6 +59,7 @@ func New(config Config) (*cobra.Command, error) {
 			path: &path{
 				Binary: []string{
 					"docker",
+					"flux",
 					"helm",
 					"istioctl",
 					"kind",

--- a/cmd/create/knd/runner.go
+++ b/cmd/create/knd/runner.go
@@ -3,6 +3,7 @@ package knd
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
@@ -137,6 +138,29 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if err != nil {
 			return tracer.Maskf(executionFailedError, "%s", out)
 		}
+	}
+
+	{
+		r.logger.Log(ctx, "level", "info", "message", "installing flux toolkit")
+
+		os.Setenv("GITHUB_TOKEN", secrets["github.flux.token"])
+
+		out, err = exec.Command(
+			"flux",
+			"bootstrap",
+			"github",
+			"--owner",
+			"venturemark",
+			"--repository",
+			"flux",
+			"--token-auth",
+			"true",
+		).CombinedOutput()
+		if err != nil {
+			return tracer.Maskf(executionFailedError, "%s", out)
+		}
+
+		os.Unsetenv("GITHUB_TOKEN")
 	}
 
 	return nil


### PR DESCRIPTION
With this PR, creating a Kubernetes cluster using `kia` installs the `flux` toolkit. 

```
$ kia create knd
{ "caller":"github.com/xh3b4sd/kia/cmd/create/knd/runner.go:53", "level":"info", "message":"decrypting local secrets", "time":"2020-12-22 22:08:26" }
{ "caller":"github.com/xh3b4sd/kia/cmd/create/knd/runner.go:67", "level":"info", "message":"creating kind cluster", "time":"2020-12-22 22:08:26" }
{ "caller":"github.com/xh3b4sd/kia/cmd/create/knd/runner.go:76", "level":"info", "message":"installing service mesh", "time":"2020-12-22 22:08:57" }
{ "caller":"github.com/xh3b4sd/kia/cmd/create/knd/runner.go:85", "level":"info", "message":"creating infra namespace", "time":"2020-12-22 22:09:53" }
{ "caller":"github.com/xh3b4sd/kia/cmd/create/knd/runner.go:99", "level":"info", "message":"installing infra chart", "time":"2020-12-22 22:09:55" }
{ "caller":"github.com/xh3b4sd/kia/cmd/create/knd/runner.go:108", "level":"info", "message":"installing istio-asset chart", "time":"2020-12-22 22:09:57" }
{ "caller":"github.com/xh3b4sd/kia/cmd/create/knd/runner.go:123", "level":"info", "message":"installing redis chart", "time":"2020-12-22 22:09:59" }
{ "caller":"github.com/xh3b4sd/kia/cmd/create/knd/runner.go:145", "level":"info", "message":"installing flux toolkit", "time":"2020-12-22 22:10:03" }
```



`flux` deploys whatever we have in https://github.com/venturemark/flux. For now only the `apiserver`. 

```
$ k get pod -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
flux-system          helm-controller-6765c95b47-7n955             1/1     Running   0          2m27s
flux-system          kustomize-controller-7f5455cd78-r2669        1/1     Running   0          2m27s
flux-system          notification-controller-694856fd64-pzwr9     1/1     Running   0          2m27s
flux-system          source-controller-5bdb7bdfc9-9p52j           1/1     Running   0          2m26s
infra                apiserver-7c5c485d6c-ng85w                   2/2     Running   0          90s
infra                apiserver-7c5c485d6c-pr425                   2/2     Running   0          90s
infra                apiserver-7c5c485d6c-sf9xg                   2/2     Running   0          90s
infra                apiserver-7c5c485d6c-zxfnv                   2/2     Running   0          90s
infra                redis-master-0                               2/2     Running   0          2m32s
istio-system         istio-ingressgateway-64cfb9d44b-qfthq        1/1     Running   0          2m58s
istio-system         istiod-7684b696d6-254sb                      1/1     Running   0          3m24s
kube-system          coredns-f9fd979d6-pqwnq                      1/1     Running   0          3m24s
kube-system          coredns-f9fd979d6-vkf62                      1/1     Running   0          3m24s
kube-system          etcd-kind-control-plane                      1/1     Running   0          3m34s
kube-system          kindnet-qp2cm                                1/1     Running   0          3m24s
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          3m34s
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          3m34s
kube-system          kube-proxy-cr2w2                             1/1     Running   0          3m24s
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          3m34s
local-path-storage   local-path-provisioner-78776bfc44-vcthz      1/1     Running   0          3m24s
```



/cc @marcusellison